### PR TITLE
Preinstall AstroNav on all PDAs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -82,6 +82,7 @@
       - NotekeeperCartridge
       - NanoTaskCartridge
       - NewsReaderCartridge
+      - AstroNavCartridge
     cartridgeSlot:
       priority: -1
       name: device-pda-slot-component-slot-name-cartridge
@@ -516,7 +517,6 @@
       - NotekeeperCartridge
       - NanoTaskCartridge
       - NewsReaderCartridge
-      - AstroNavCartridge
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
See title

## Why / Balance
Already do it using spawned cartridges, makes it a lot easier.

## Technical details
It's one line of YAML

## Media
![image](https://github.com/user-attachments/assets/67b302aa-deb1-4921-90ea-24a99dd02b1e)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
nuh uh

**Changelog**
:cl:
- add: All PDAs now come equipped with the AstroNav program preinstalled
